### PR TITLE
feat(theme): Implementar toggler de tema oscuro/claro

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -122,6 +122,7 @@
 
  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="./js/theme.js"></script>
 </body>
 
 </html>

--- a/css/estilo.css
+++ b/css/estilo.css
@@ -22,14 +22,55 @@
   --color-secondary: #f0f8ff;
   --color-border: #d0d7de;
   --shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --gradient-start: #dbe5f0;
+  --gradient-end: #e5ecf3;
+  --nav-link-hover-text: var(--color-bg);
   --transition: 0.3s ease;
   --bs-body-font-family: "Inter", sans-serif;
 }
 
+/* Dark theme */
+[data-bs-theme="dark"] {
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-primary: #ffffff;
+  --color-muted: #b0b0b0;
+  --color-border: #333333;
+  --color-secondary: #2a2a2a;
+  --shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  --gradient-start: #1a1a1a;
+  --gradient-end: #121212;
+  --nav-link-hover-text: #ffffff;
+  --bs-body-color: var(--color-primary);
+  --bs-body-bg: var(--color-bg);
+  --bs-border-color: var(--color-border);
+  --bs-secondary-bg: var(--color-secondary);
+  --bs-secondary-rgb: 42,42,42;
+}
+
+[data-bs-theme="dark"] .bg-light {
+  background-color: var(--color-surface) !important;
+}
+
+[data-bs-theme="dark"] .logo-os {
+  filter: grayscale(100%) invert(1);
+}
+
+[data-bs-theme="dark"] .text-primary-emphasis {
+  color: var(--bs-primary) !important;
+}
+
+[data-bs-theme="dark"] .hero .text-primary {
+  color: var(--bs-primary) !important;
+}
+/* EndDark theme */
+
+
 body {
-  background: radial-gradient(circle at top left, #dbe5f0, #e5ecf3);
+  background: radial-gradient(circle at top left, var(--gradient-start), var(--gradient-end));
   min-height: 100vh;
   flex-direction: column;
+  display: flex;
   transition: background var(--transition), color var(--transition);
 }
 
@@ -66,7 +107,7 @@ body {
 .navbar-nav .nav-link:hover {
   transition: all var(--transition);
   background-color: var(--color-accent);
-  color: var(--color-bg);
+  color: var(--nav-link-hover-text);
 }
 
 @media (min-width: 992px) {
@@ -420,7 +461,8 @@ footer a:hover {
   padding: 0.5rem;
   border: 1px solid var(--color-border);
   border-radius: 4px;
-  background-color: #f5f5f5;
+  background-color: var(--bs-secondary-bg);
+  color: var(--bs-body-color);
 }
 
 .contact-form form {
@@ -477,6 +519,20 @@ footer a:hover {
   margin: 1rem 0;
   line-height: 1.8;
 }
+
+/* Theme Button */
+@media (width > 992px) {
+  .theme-toggle{
+    transition: all var(--transition);
+  }
+  .theme-toggle i {
+    color: var(--bs-primary);
+  }
+  .theme-toggle:hover {
+    transform: scale(1.1);
+  }
+}
+/* End Theme Button */
 
 /* Animaciones */
 @keyframes fadeIn {

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
           </ul>
         </div>
       </div>
+    </nav>
   </header>
   <section class="hero py-5 bg-primary text-white">
     <div class="container z-1">
@@ -266,9 +267,11 @@
     </div>
   </footer>
 
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
     crossorigin="anonymous"></script>
+    <script src="./js/theme.js"></script>
 </body>
 
 </html>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,121 @@
+class ThemeUI {
+  static TOGGLE_BUTTON_ID = "themeToggle";
+  static ICON_ELEMENT_ID = "themeIcon";
+  static LIGHT_ICON_CLASS = "fa fs-5 fa-moon";
+  static DARK_ICON_CLASS = "fa fs-5 fa-sun";
+  static EVENT_CLICK = "click";
+  static ELEMENT_BUTTON = "button";
+  static ELEMENT_ICON = "i";
+  static ELEMENT_SPAN = "span";
+  static ELEMENT_LIST_ITEM = "li";
+  static TOGGLE_BUTTON_CLASSES =
+    "btn theme-toggle btn-link py-lg-2 py-3 text-muted d-flex align-items-center text-decoration-none p-2";
+  static ATTRIBUTE_ARIA_LABEL = "aria-label";
+  static ATTRIBUTE_TITLE = "title";
+  static ATTRIBUTE_TYPE = "type";
+  static LABEL_CHANGE_THEME = "Cambiar Tema";
+  static TITLE_CHANGE_THEME = "Cambiar tema claro/oscuro";
+  static SPAN_CLASSES = "ms-2 d-lg-none";
+
+  constructor({ containerSelector, wrapper, onClick }) {
+    this.createToggle(containerSelector, wrapper);
+    this.bindEvents(onClick);
+  }
+
+  createToggle(containerSelector, wrapper) {
+    if (document.getElementById(ThemeUI.TOGGLE_BUTTON_ID)) {
+      return;
+    }
+
+    const container = document.querySelector(containerSelector);
+    if (!container) {
+      console.error(`ThemeUI: Container "${containerSelector}" no encontrado.`);
+      return;
+    }
+
+    const buttonHTML = `
+      <button id="${ThemeUI.TOGGLE_BUTTON_ID}" class="${ThemeUI.TOGGLE_BUTTON_CLASSES}"
+              type="${ThemeUI.ELEMENT_BUTTON}"
+              aria-label="${ThemeUI.LABEL_CHANGE_THEME}"
+              title="${ThemeUI.TITLE_CHANGE_THEME}">
+        <i id="${ThemeUI.ICON_ELEMENT_ID}"></i>
+        <span class="${ThemeUI.SPAN_CLASSES}">${ThemeUI.LABEL_CHANGE_THEME}</span>
+      </button>
+    `;
+
+    if (wrapper?.tag) {
+      const wrapperElement = document.createElement(wrapper.tag);
+      if (wrapper?.classes) {
+        wrapperElement.className = wrapper.classes;
+      }
+      wrapperElement.innerHTML = buttonHTML;
+      container.appendChild(wrapperElement);
+    } else {
+      container.innerHTML += buttonHTML;
+    }
+
+    this.themeToggleElement = document.getElementById(ThemeUI.TOGGLE_BUTTON_ID);
+    this.themeIconElement = document.getElementById(ThemeUI.ICON_ELEMENT_ID);
+  }
+
+  bindEvents(callback) {
+    if (this.themeToggleElement) {
+      this.themeToggleElement.addEventListener(ThemeUI.EVENT_CLICK, callback);
+    }
+  }
+
+  updateIcon(theme) {
+    if (this.themeIconElement) {
+      this.themeIconElement.className =
+        theme === ThemeManager.DEFAULT_THEME
+          ? ThemeUI.LIGHT_ICON_CLASS
+          : ThemeUI.DARK_ICON_CLASS;
+    }
+  }
+}
+
+class ThemeManager {
+  static KEY_THEME = "bsTheme";
+  static DEFAULT_THEME = "light";
+  static DARK_THEME = "dark";
+  static DATA_THEME_ATTRIBUTE = "data-bs-theme";
+
+  constructor() {
+    this.currentTheme = this.getStoredTheme() || ThemeManager.DEFAULT_THEME;
+    this.ui = new ThemeUI({
+      containerSelector: ".navbar-nav",
+      wrapper: {
+        tag: "li",
+        classes: "ms-lg-3",
+      },
+      onClick: this.toggleTheme.bind(this),
+    });
+    this.applyTheme(this.currentTheme);
+  }
+
+  getStoredTheme() {
+    return localStorage.getItem(ThemeManager.KEY_THEME);
+  }
+
+  toggleTheme() {
+    const newTheme =
+      this.currentTheme === ThemeManager.DEFAULT_THEME
+        ? ThemeManager.DARK_THEME
+        : ThemeManager.DEFAULT_THEME;
+    this.applyTheme(newTheme);
+  }
+
+  applyTheme(theme) {
+    document.documentElement.setAttribute(
+      ThemeManager.DATA_THEME_ATTRIBUTE,
+      theme
+    );
+    localStorage.setItem(ThemeManager.KEY_THEME, theme);
+    this.currentTheme = theme;
+    this.ui.updateIcon(theme);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  new ThemeManager();
+});


### PR DESCRIPTION
## Descripción

- **Implementación de modo oscuro:** Se agregó un boton que permite alternar entre tema claro y oscuro utilizando las utilidades de Bootstrap y CSS variables.
- **Persistencia de preferencia:** El tema seleccionado se mantiene entre sesiones mediante almacenamiento local del navegador.
- **Integración con Bootstrap:** Se aprovecharon las clases de utilidad de Bootstrap (`data-bs-theme`) para gestionar los cambios de tema de forma nativa.
- **Iconografía adaptativa:** Se incorporaron iconos (sol/luna) que se actualizan dinámicamente según el tema activo.


## Demostración

### Funcionamiento del boton
![brave_Eshgs4PlBy](https://github.com/user-attachments/assets/4f6941ff-afa5-45a3-9522-11c30a5527e0)
