### PR TITLE
feat(admin): implementar control de acceso por roles en panel admin

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,6 +1,7 @@
 import { AuthError, createHttpClient } from './shared/http-client.js';
 
 const BASE_URL = 'https://dummyjson.com';
+export const ALLOWED_ROLES = ["admin", "moderator"];
 
 const api = createHttpClient(BASE_URL);
 
@@ -29,16 +30,18 @@ export const apiService = {
     return api.get(endpoint);
   },
 
+
   /**
-   * Valida un accessToken de autenticación.
+   * Valida un accessToken de autenticación y verifica si el usuario tiene un rol permitido.
    * @param {string} accessToken - El accessToken a validar.
-   * @returns {Promise<boolean>} Una promesa que resuelve a `true` si el accessToken es válido, `false` de lo contrario.
+   * @param {string[]} [allowed_roles=ALLOWED_ROLES] - Roles permitidos para la validación.
+   * @returns {Promise<boolean>} Una promesa que resuelve a `true` si el accessToken es válido y el usuario tiene un rol permitido, `false` de lo contrario.
    */
-  validateToken: async (accessToken) => {
+  validateAdminToken: async (accessToken, allowedRoles = ALLOWED_ROLES) => {
     if (!accessToken) return false;
     try {
-      await api.get('/auth/me', accessToken);
-      return true;
+      const user = await api.get('/auth/me', accessToken);
+      return allowedRoles.includes(user?.role)
     } catch (error) {
       if (error instanceof AuthError) {
         return false;

--- a/js/login.js
+++ b/js/login.js
@@ -72,6 +72,10 @@ const handleLogin = async (event) => {
   try {
     const {user,success} = await apiService.login({username, password})
     if (success){
+      const isAdministrator = await apiService.validateAdminToken(user.accessToken)
+      if (!isAdministrator){
+        throw new Error(MESSAGES.INVALID_ROLE)
+      }
       storageService.session.set(user)
       auth.redirectToAdmin()
     }

--- a/js/shared/auth.js
+++ b/js/shared/auth.js
@@ -23,7 +23,7 @@ export const auth = {
 	gatekeep: async (redirectUrl = PAGES.LOGIN) => {
 			const session = storageService.session.get();
 			const token = session?.accessToken;
-			const isUserAuthenticated  = await apiService.validateToken(token);
+			const isUserAuthenticated  = await apiService.validateAdminToken(token);
 			if (!isUserAuthenticated) {
         storageService.session.clear()
 				auth.redirectTo(redirectUrl);

--- a/js/shared/constants.js
+++ b/js/shared/constants.js
@@ -6,7 +6,8 @@ export const MESSAGES = {
     ENTITY_DELETE_SUCCESS : (entityName) =>`${entityName} fue eliminada con éxito.`,
     CONFIRM_DELETE : (entityName) =>`¿Está seguro de que desea eliminar esta ${entityName}? Esta acción no se puede deshacer.`,
     ENTITY_LOAD_ERROR : (entityName) =>`Error al cargar ${entityName}. Intente nuevamente.`,
-    INVALID_CREDENTIALS: "Credenciales inválidas. Usuario y/o Password Inválidos."
+    INVALID_CREDENTIALS: "Credenciales inválidas. Usuario y/o Password Inválidos.",
+    INVALID_ROLE: "Usted no tiene los permisos necesarios para acceder a esta sección. Contacte al administrador."
 };
 
 export const PAGES = {


### PR DESCRIPTION
- Solo usuarios con role admin/moderator pueden acceder
- Validación de roles en login y gatekeep
- Mensajes de error descriptivos
- Refactorizar validateAdminToken para aceptar roles configurables

<img width="1836" height="733" alt="zoomit" src="https://github.com/user-attachments/assets/5ccca4eb-06f1-49e2-8282-fb99e7afc0e5" />
